### PR TITLE
for cisagov/icsnpp-synchrophasor#16, put an @if around analyzer_confirmation/analyzer_confirmation_info for Zeek versioning

### DIFF
--- a/analyzer/main.zeek
+++ b/analyzer/main.zeek
@@ -80,12 +80,17 @@ event zeek_init() &priority=5 {
 }
 
 #############################################################################
+@if (Version::at_least("6.1.0"))
 event analyzer_confirmation_info(atype: AllAnalyzers::Tag, info: AnalyzerConfirmationInfo) {
-
   if ( atype == Analyzer::ANALYZER_GENISYS_TCP ) {
     info$c$genisys_proto = "tcp";
   }
-
+@else
+event analyzer_confirmation(c: connection, atype: Analyzer::Tag, aid: count) &priority=5 {
+  if ( atype == Analyzer::ANALYZER_GENISYS_TCP ) {
+    c$genisys_proto = "tcp";
+  }
+@endif
 }
 
 #############################################################################


### PR DESCRIPTION
for cisagov/icsnpp-synchrophasor#16, put an @if around analyzer_confirmation/analyzer_confirmation_info for Zeek versioning.

the plugin now installs and runs correctly. With older Zeek the unit tests fail due to restructuring of scripting install by zeek packages (e.g., the location of `canonify-zeek-log-sorted`) but the package works correctly when installed with `--skiptests`