### PR TITLE
Fix compilation for Spicy v1.13.0

### DIFF
--- a/analyzer/analyzer.spicy
+++ b/analyzer/analyzer.spicy
@@ -218,7 +218,8 @@ type PayloadPairs = unit (payloadLen: uint64) {
       if (idx % 2 == 0) {
         address = i;
       } else {
-        self.payload.push_back((address, i));
+        local x = i;
+        self.payload.push_back((address, x));
       }
       idx++;
     }


### PR DESCRIPTION
Due to zeek/spicy#2057 (thanks @bbannier for the assist in figuring out what was happening) we need to force the creation of a wrapped integer for a local variable in one of the functions in the genisys parser.

With this patch the package installs (with passing unit tests) with Zeek 7.2.0/Spicy 1.13.0.